### PR TITLE
[FEAT] Kakao Cloud Kubernetes Infrastructure

### DIFF
--- a/k8s/auth-service/namespace.yaml
+++ b/k8s/auth-service/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: auth-service
+  labels:
+    name: auth-service

--- a/k8s/nginx-ingress/helm/values.yaml
+++ b/k8s/nginx-ingress/helm/values.yaml
@@ -8,7 +8,7 @@ image:
 # Service configuration
 service:
   type: LoadBalancer
-  externalIPs: []  # LoadBalancer가 자동으로 할당
+  externalIPs: ["210.109.55.201"]  # 수동으로 External IP 할당
   ports:
     - name: http
       port: 80
@@ -32,7 +32,7 @@ component: ingress-controller
 controller:
   service:
     type: LoadBalancer
-    externalIPs: []  # LoadBalancer가 자동으로 할당
+    externalIPs: ["210.109.55.201"]  # 수동으로 External IP 할당
     ports:
       http: 80
       https: 443

--- a/k8s/redis/helm/templates/networkpolicy.yaml
+++ b/k8s/redis/helm/templates/networkpolicy.yaml
@@ -1,0 +1,31 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/instance: redis
+    app.kubernetes.io/managed-by: Helm
+    app.kubernetes.io/version: "8.0.3"
+    helm.sh/chart: redis-0.1.0
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/name: redis
+      app.kubernetes.io/instance: redis
+  policyTypes:
+    - Ingress
+    - Egress
+  {{- if .Values.networkPolicy.ingress }}
+  ingress:
+    {{- toYaml .Values.networkPolicy.ingress | nindent 4 }}
+  {{- end }}
+  {{- if .Values.networkPolicy.egress }}
+  egress:
+    {{- toYaml .Values.networkPolicy.egress | nindent 4 }}
+  {{- else }}
+  egress:
+    - {}
+  {{- end }}
+{{- end }}

--- a/k8s/redis/helm/values.yaml
+++ b/k8s/redis/helm/values.yaml
@@ -123,8 +123,15 @@ podDisruptionBudget:
 
 # Network policy
 networkPolicy:
-  enabled: false
-  ingress: []
+  enabled: true
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              name: auth-service
+      ports:
+        - port: 6379
+          protocol: TCP
   egress: []
 
 # Service account

--- a/terraform/test/.gitignore
+++ b/terraform/test/.gitignore
@@ -1,0 +1,31 @@
+# Terraform 파일
+*.tfstate
+*.tfstate.*
+*.tfvars
+*.tfplan
+*.tfplan.*
+
+# Terraform 디렉토리
+.terraform/
+.terraform.lock.hcl
+
+# 환경변수 파일
+.env
+.env.local
+.env.*.local
+
+# 로그 파일
+*.log
+
+# 임시 파일
+*.tmp
+*.temp
+
+# OS 생성 파일
+.DS_Store
+Thumbs.db
+
+# key
+/keys/*
+kubeconfig/*
+/secret/*

--- a/terraform/test/applications/auth-service-app.yaml
+++ b/terraform/test/applications/auth-service-app.yaml
@@ -1,0 +1,29 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: auth-service
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/KE-WhyNot/INFRA
+    targetRevision: develop
+    path: k8s/auth-service
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: auth-service
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/terraform/test/applications/mysql-app.yaml
+++ b/terraform/test/applications/mysql-app.yaml
@@ -1,0 +1,45 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mysql
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  project: default
+  source:
+    repoURL: registry-1.docker.io/bitnamicharts
+    chart: mysql
+    targetRevision: "14.0.3"
+    helm:
+      parameters:
+        - name: primary.persistence.enabled
+          value: "false"
+        - name: persistence.enabled
+          value: "false"
+        - name: primary.resources.requests.memory
+          value: "128Mi"
+        - name: primary.resources.requests.cpu
+          value: "100m"
+        - name: auth.existingSecret
+          value: "mysql-secrets"
+        - name: auth.database
+          value: "auth"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mysql
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/terraform/test/applications/redis-app.yaml
+++ b/terraform/test/applications/redis-app.yaml
@@ -1,0 +1,44 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: redis
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io/foreground
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/parkyoungdu/INFRA.git
+    path: k8s/redis/helm
+    targetRevision: develop
+    helm:
+      values: |
+        networkPolicy:
+          enabled: true
+          ingress:
+            - from:
+                - namespaceSelector:
+                    matchLabels:
+                      name: auth-service
+              ports:
+                - port: 6379
+                  protocol: TCP
+          egress: []
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: redis
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 10
+      backoff:
+        duration: 10s
+        factor: 2
+        maxDuration: 5m

--- a/terraform/test/helm.tf
+++ b/terraform/test/helm.tf
@@ -1,0 +1,80 @@
+# Nginx Ingress Controller를 Helm으로 설치
+resource "helm_release" "nginx_ingress" {
+  name       = "ingress-nginx"
+  repository = "https://kubernetes.github.io/ingress-nginx"
+  chart      = "ingress-nginx"
+  namespace  = "ingress-nginx"
+  version    = "4.8.3"
+  
+  create_namespace = true
+  wait              = false
+  timeout           = 600
+  atomic            = false
+  
+  force_update = true
+  replace = true
+  
+  # OpenStack 환경에 맞는 설정을 values 파일로 관리
+  values = [
+    file("helm/nginx/values.yaml")
+  ]
+  
+  depends_on = [null_resource.preclean_ingress, null_resource.copy_kubeconfig, null_resource.wait_for_k8s_api]
+}
+
+## NGINX Ingress Controller 롤아웃/진단
+resource "null_resource" "nginx_ingress_diagnostics" {
+  depends_on = [helm_release.nginx_ingress]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo "[nginx] 컨트롤러 배포 상태 확인 중..."
+      # 실시간 진행도 (rollout status)
+      kubectl -n ingress-nginx rollout status deploy/ingress-nginx-controller --timeout=5m || true
+      echo "[nginx] 파드 목록:" && kubectl -n ingress-nginx get pods -o wide || true
+      echo "[nginx] 서비스 목록:" && kubectl -n ingress-nginx get svc -o wide || true
+      echo "[nginx] 최근 이벤트:" && kubectl -n ingress-nginx get events --sort-by=.lastTimestamp | tail -n 50 || true
+      echo "[nginx] 컨트롤러 상세:" && kubectl -n ingress-nginx describe deploy/ingress-nginx-controller | tail -n 80 || true
+    EOT
+  }
+}
+
+resource "helm_release" "argocd" {
+  name = "argocd"
+
+  repository       = "https://argoproj.github.io/argo-helm"
+  chart            = "argo-cd"
+  namespace        = "argocd"
+  version          = "6.7.12"
+  create_namespace = true
+  wait              = false
+  timeout           = 600
+  atomic            = false
+
+  values = [
+    file("helm/argocd/values.yaml")
+  ]
+
+  depends_on = [null_resource.preclean_argocd, null_resource.copy_kubeconfig, null_resource.wait_for_k8s_api, helm_release.nginx_ingress]
+}
+
+# Redis는 이제 ArgoCD Application으로 관리됩니다
+# Redis Application 매니페스트: applications/redis-app.yaml
+
+## ArgoCD 롤아웃/진단
+resource "null_resource" "argocd_diagnostics" {
+  depends_on = [helm_release.argocd]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo "[argocd] 서버 배포 상태 확인 중..."
+      kubectl -n argocd rollout status deploy/argocd-server --timeout=5m || true
+      echo "[argocd] 파드 목록:" && kubectl -n argocd get pods -o wide || true
+      echo "[argocd] 서비스 목록:" && kubectl -n argocd get svc -o wide || true
+      echo "[argocd] 최근 이벤트:" && kubectl -n argocd get events --sort-by=.lastTimestamp | tail -n 50 || true
+      echo "[argocd] 서버 상세:" && kubectl -n argocd describe deploy/argocd-server | tail -n 80 || true
+    EOT
+  }
+}

--- a/terraform/test/helm/argocd/values.yaml
+++ b/terraform/test/helm/argocd/values.yaml
@@ -1,0 +1,119 @@
+# ArgoCD 공식 Helm Chart 커스텀 Values
+# 포트 8000으로 변경 및 우리 서비스들 자동 등록
+
+global:
+  # 도메인 설정
+  domain: localhost:8000
+
+# 서버 설정
+server:
+  # 서비스 설정
+  service:
+    type: LoadBalancer
+    servicePortHttp: 8000
+    servicePortHttps: 8443
+
+  # Ingress 비활성화 (LoadBalancer 사용)
+  ingress:
+    enabled: false
+
+  # 추가 설정
+  extraArgs:
+    - --insecure
+
+  # 리소스 제한
+  resources:
+    limits:
+      cpu: 300m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+# Application Controller 설정
+controller:
+  resources:
+    limits:
+      cpu: 300m
+      memory: 512Mi
+    requests:
+      cpu: 100m
+      memory: 256Mi
+
+# Repository Server 설정
+repoServer:
+  resources:
+    limits:
+      cpu: 1000m
+      memory: 1Gi
+    requests:
+      cpu: 500m
+      memory: 512Mi
+
+# Redis 설정
+redis:
+  enabled: true  # Redis 캐싱 활성화
+
+# Dex 서버 설정 (인증)
+dex:
+  enabled: false  # 개발환경에서는 비활성화
+
+# Notifications Controller 설정
+notifications:
+  enabled: true
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+# ApplicationSet Controller 설정
+applicationSet:
+  enabled: true
+  resources:
+    limits:
+      cpu: 100m
+      memory: 128Mi
+    requests:
+      cpu: 50m
+      memory: 64Mi
+
+# 설정 관리
+configs:
+  # 매개변수 설정
+  params:
+    server.insecure: true
+    server.disable.auth: false
+    application.instanceLabelKey: argocd.argoproj.io/instance
+    # 캐시 비활성화 설정
+    timeout.hard.reconciliation: 1s  # 캐시 타임아웃을 1초로 설정 (거의 비활성화)
+    timeout.reconciliation: 30s      # 일반 reconciliation 타임아웃 단축
+
+  # 저장소 설정
+  repositories:
+    infra-repo:
+      type: git
+      url: https://github.com/KE-WhyNot/INFRA
+      name: infra-repo
+    bitnami-oci:
+      type: helm
+      name: bitnami-oci
+      url: oci://registry-1.docker.io/bitnamicharts
+      enableOCI: "true"
+
+  # RBAC 설정
+  rbac:
+    policy.default: role:readonly
+    policy.csv: |
+      p, role:admin, applications, *, */*, allow
+      p, role:admin, certificates, *, *, allow
+      p, role:admin, clusters, *, *, allow
+      p, role:admin, repositories, *, *, allow
+      p, role:admin, projects, *, *, allow
+      g, argocd-admins, role:admin
+
+# 초기 관리자 계정 설정 유지
+  config:
+    url: http://localhost:8000

--- a/terraform/test/helm/nginx/values.yaml
+++ b/terraform/test/helm/nginx/values.yaml
@@ -1,0 +1,32 @@
+controller:
+  replicaCount: 1
+  service:
+    enabled: true
+    type: LoadBalancer
+    annotations:
+      # Octavia LoadBalancer 설정
+      openstack.org/load-balancer-provider: octavia
+      openstack.org/load-balancer-floating-network-id: "EXTERNAL"
+      openstack.org/load-balancer-floating-subnet-id: "EXTERNAL"
+      # LoadBalancer 클래스 설정
+      service.beta.kubernetes.io/openstack-load-balancer-class: "octavia"
+  config:
+    use-proxy-protocol: "false"
+    compute-full-forwarded-for: "true"
+    use-forwarded-headers: "true"
+    enable-ssl-passthrough: "true"
+  resources:
+    limits:
+      cpu: 600m
+      memory: 1Gi
+    requests:
+      cpu: 300m
+      memory: 512Mi
+  nodeSelector:
+    node-role.kubernetes.io/control-plane: ""
+  tolerations:
+    - key: node-role.kubernetes.io/control-plane
+      operator: Exists
+      effect: NoSchedule
+  controller:
+

--- a/terraform/test/main.tf
+++ b/terraform/test/main.tf
@@ -1,0 +1,950 @@
+data "openstack_compute_flavor_v2" "master" {
+  name = var.master_flavor_name
+}
+# 카카오클라우드 자체 구축 Kubernetes 클러스터
+
+# 1. 네트워크 리소스 (OpenStack)
+data "openstack_networking_network_v2" "existing_vpc" {
+  count = length(var.existing_vpc_id) > 0 ? 1 : 0
+  network_id = var.existing_vpc_id
+}
+
+data "openstack_networking_subnet_v2" "existing_subnets" {
+  count = length(var.existing_subnet_ids)
+  subnet_id = var.existing_subnet_ids[count.index]
+}
+
+# 2. SSH 키페어 조회
+data "openstack_compute_keypair_v2" "k8s_keypair" {
+  name = var.ssh_key_name
+}
+
+# 3. 보안그룹 (Kubernetes 워커 노드용)
+resource "openstack_networking_secgroup_v2" "k8s_worker_security_group" {
+  name        = "${var.k8s_cluster_name}-worker-sg-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+  description = "Kubernetes Worker Nodes Security Group"
+}
+
+# 3-1. 보안그룹 (Kubernetes 마스터 노드용)
+resource "openstack_networking_secgroup_v2" "k8s_master_security_group" {
+  name        = "${var.k8s_cluster_name}-master-sg-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+  description = "Kubernetes Master Node Security Group"
+}
+
+# 마스터 노드 전용 보안 그룹 규칙들
+resource "openstack_networking_secgroup_rule_v2" "master_ssh_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_http_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_https_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+# 마스터 노드용 Kubernetes API 서버 포트
+resource "openstack_networking_secgroup_rule_v2" "master_k8s_api_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_icmp_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+# 마스터 노드에서 워커 노드로의 통신 허용
+resource "openstack_networking_secgroup_rule_v2" "master_to_worker_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "10.0.0.0/20"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_to_worker_udp_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "10.0.0.0/20"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+# 마스터 노드 egress 규칙
+resource "openstack_networking_secgroup_rule_v2" "master_all_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "master_all_udp_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_master_security_group.id
+}
+
+# 3-2. 보안그룹 (Kubernetes 로드밸런서용)
+resource "openstack_networking_secgroup_v2" "k8s_lb_security_group" {
+  name        = "${var.k8s_cluster_name}-lb-sg-${formatdate("YYYYMMDD-hhmm", timestamp())}"
+  description = "Kubernetes LoadBalancer Security Group"
+}
+
+# 4. 보안그룹 규칙들 (워커 노드용)
+# DHCP 응답 수신 (인스턴스가 IP 못 받으면 SSH 절대 안 열립니다)
+resource "openstack_networking_secgroup_rule_v2" "dhcp_client_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 68
+  port_range_max    = 68
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "dhcp_client_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 67
+  port_range_max    = 67
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+# 진단/MTU 문제 방지용
+resource "openstack_networking_secgroup_rule_v2" "icmp_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "icmp"
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "ssh_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "k8s_api_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "http_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "https_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "nodeport_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+# 워커가 마스터에서 join-command를 HTTP(8080)로 가져오기 위한 내부 통신 허용
+resource "openstack_networking_secgroup_rule_v2" "join_http_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 8080
+  port_range_max    = 8080
+  remote_ip_prefix  = local.master_subnet.cidr
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+# 노드 간 필수 통신 허용 (Kubelet, Flannel VXLAN)
+resource "openstack_networking_secgroup_rule_v2" "kubelet_internal_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 10250
+  port_range_max    = 10250
+  remote_ip_prefix  = local.master_subnet.cidr
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "flannel_vxlan_internal_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 8472
+  port_range_max    = 8472
+  remote_ip_prefix  = local.master_subnet.cidr
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+# 메타데이터 서버 통신을 위한 HTTP 규칙 (SSH 키 설정용)
+resource "openstack_networking_secgroup_rule_v2" "metadata_http_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "169.254.169.254/32"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "all_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+resource "openstack_networking_secgroup_rule_v2" "all_udp_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "udp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+}
+
+# 4-1. 보안그룹 규칙들 (로드밸런서용)
+# HTTP 트래픽
+resource "openstack_networking_secgroup_rule_v2" "lb_http_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 80
+  port_range_max    = 80
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_lb_security_group.id
+}
+
+# HTTPS 트래픽
+resource "openstack_networking_secgroup_rule_v2" "lb_https_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 443
+  port_range_max    = 443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_lb_security_group.id
+}
+
+# 로드밸런서용 Kubernetes API 서버 포트
+resource "openstack_networking_secgroup_rule_v2" "lb_k8s_api_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 6443
+  port_range_max    = 6443
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_lb_security_group.id
+}
+
+# 로드밸런서용 SSH 포트
+resource "openstack_networking_secgroup_rule_v2" "lb_ssh_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 22
+  port_range_max    = 22
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_lb_security_group.id
+}
+
+# 로드밸런서용 NodePort 범위 (Kubernetes NodePort 서비스용)
+resource "openstack_networking_secgroup_rule_v2" "lb_nodeport_ingress" {
+  direction         = "ingress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 30000
+  port_range_max    = 32767
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_lb_security_group.id
+}
+
+# 로드밸런서 아웃바운드 트래픽
+resource "openstack_networking_secgroup_rule_v2" "lb_all_egress" {
+  direction         = "egress"
+  ethertype         = "IPv4"
+  protocol          = "tcp"
+  port_range_min    = 1
+  port_range_max    = 65535
+  remote_ip_prefix  = "0.0.0.0/0"
+  security_group_id = openstack_networking_secgroup_v2.k8s_lb_security_group.id
+}
+
+# 5. 마스터 노드 포트(고정 IP/보안그룹 명시) 생성
+resource "openstack_networking_port_v2" "k8s_master_port" {
+  name                = "${var.k8s_cluster_name}-master-port"
+  network_id          = local.vpc_id
+  admin_state_up      = true
+  security_group_ids  = [openstack_networking_secgroup_v2.k8s_master_security_group.id]
+
+  fixed_ip {
+    subnet_id = local.master_subnet.id
+    ip_address = cidrhost(local.master_subnet.cidr, 10)
+  }
+}
+
+# 마스터 노드 Floating IP 제거 (로드밸런서를 통한 접속 사용)
+
+# 7. 마스터 노드 생성
+resource "openstack_compute_instance_v2" "k8s_master" {
+  count           = var.master_node_count
+  name            = "${var.k8s_cluster_name}-master-${count.index + 1}"
+  image_id        = var.master_image_id
+  #flavor_id       = var.master_flavor_id
+  flavor_id       = coalesce(try(data.openstack_compute_flavor_v2.master.id, null), var.master_flavor_id)
+  key_pair        = data.openstack_compute_keypair_v2.k8s_keypair.name
+  security_groups = [] # 포트 수준에서 SG 적용
+
+  network {
+    port = openstack_networking_port_v2.k8s_master_port.id
+  }
+
+  block_device {
+    uuid                  = var.master_image_id
+    source_type           = "image"
+    destination_type      = "volume"
+    volume_size           = var.master_volume_size
+    boot_index            = 0
+    delete_on_termination = true
+  }
+
+  metadata = {
+    role = "master"
+    cluster = var.k8s_cluster_name
+    node_index = count.index + 1
+  }
+
+  tags = [for k, v in var.tags : "${k}=${v}"]
+}
+
+# 8. Floating IP를 포트에 연결 (인스턴스 부팅 후)
+# Floating IP 연결 제거 (로드밸런서를 통한 접속 사용)
+
+# 11. 워커 노드 생성
+resource "openstack_compute_instance_v2" "k8s_worker" {
+  count           = var.worker_node_count * var.worker_nodes_per_pool
+  name            = "${var.k8s_cluster_name}-worker-${count.index + 1}"
+  image_id        = var.worker_image_id
+  flavor_id       = var.worker_flavor_id
+  key_pair        = data.openstack_compute_keypair_v2.k8s_keypair.name
+  security_groups = []
+
+  network {
+    port = openstack_networking_port_v2.k8s_worker_port[count.index].id
+  }
+
+  block_device {
+    uuid                  = var.worker_image_id
+    source_type           = "image"
+    destination_type      = "volume"
+    volume_size           = var.worker_volume_size
+    boot_index            = 0
+    delete_on_termination = true
+  }
+
+  metadata = {
+    role = "worker"
+    cluster = var.k8s_cluster_name
+    node_index = count.index + 1
+  }
+
+  tags = [for k, v in var.tags : "${k}=${v}"]
+
+  # cloud-init으로 SSH 없이 자동 조인
+  user_data = <<-CLOUD
+    #cloud-config
+    package_update: true
+    packages:
+      - apt-transport-https
+      - ca-certificates
+      - curl
+      - gnupg
+      - lsb-release
+    runcmd:
+      - |
+        set -e
+        # 컨테이너 런타임 및 Kubernetes 설치
+        curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor | tee /usr/share/keyrings/docker-archive-keyring.gpg > /dev/null
+        echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" > /etc/apt/sources.list.d/docker.list
+        mkdir -p /etc/apt/keyrings
+        curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | gpg --dearmor | tee /etc/apt/keyrings/kubernetes-apt-keyring.gpg > /dev/null
+        echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' > /etc/apt/sources.list.d/kubernetes.list
+        apt-get update
+        apt-get install -y docker-ce docker-ce-cli containerd.io kubelet kubeadm kubectl
+        apt-mark hold kubelet kubeadm kubectl || true
+        swapoff -a || true
+        sed -i.bak '/\sswap\s/s/^/#/' /etc/fstab || true
+        modprobe br_netfilter || true
+        echo 1 > /proc/sys/net/bridge/bridge-nf-call-iptables || true
+        echo 1 > /proc/sys/net/ipv4/ip_forward || true
+        printf "net.bridge.bridge-nf-call-iptables = 1\nnet.ipv4.ip_forward = 1\n" > /etc/sysctl.d/k8s.conf
+        sysctl --system || true
+        mkdir -p /etc/containerd
+        if command -v containerd >/dev/null 2>&1; then
+          containerd config default > /etc/containerd/config.toml || true
+          sed -i 's/^\(\s*SystemdCgroup\s*=\s*\)false/\1true/' /etc/containerd/config.toml || true
+          systemctl restart containerd || true
+          systemctl enable containerd || true
+        fi
+        systemctl enable docker || true
+        systemctl start docker || true
+        # 마스터 내부 IP로 join-command 받기
+        MASTER_IP="${cidrhost(local.master_subnet.cidr, 10)}"
+        LOG_FILE=/var/log/kubeadm-join.log
+        echo "[cloud-init] starting join sequence" | tee -a "$LOG_FILE"
+
+        # 1) join-command 가져오기: 최대 60회, 10초 간격
+        for i in $(seq 1 60); do
+          echo "[cloud-init] fetching join-command (attempt $i)..." | tee -a "$LOG_FILE"
+          JOIN_CMD=$(curl -fsS http://$MASTER_IP:8080/join-command.sh || true)
+          if [ -n "$JOIN_CMD" ]; then
+            echo "$JOIN_CMD" > /root/join.sh
+            chmod +x /root/join.sh
+            echo "[cloud-init] join-command fetched" | tee -a "$LOG_FILE"
+            break
+          fi
+          sleep 10
+        done
+
+        # 2) kubeadm join 재시도: 최대 20회, 10초 간격 (실패 시 reset 후 재시도)
+        if [ -s /root/join.sh ]; then
+          for j in $(seq 1 20); do
+            echo "[cloud-init] executing kubeadm join (try $j/20)" | tee -a "$LOG_FILE"
+            if bash -c "sudo /root/join.sh" >> "$LOG_FILE" 2>&1; then
+              echo "[cloud-init] kubeadm join success" | tee -a "$LOG_FILE"
+              break
+            else
+              echo "[cloud-init] kubeadm join failed, resetting and retrying..." | tee -a "$LOG_FILE"
+              kubeadm reset -f >> "$LOG_FILE" 2>&1 || true
+              systemctl restart kubelet || true
+              sleep 10
+            fi
+          done
+        else
+          echo "[cloud-init] failed to fetch join command" | tee -a "$LOG_FILE" >&2
+        fi
+  CLOUD
+}
+
+# 12. 워커 노드용 포트 생성 (보안그룹을 포트에 직접 적용)
+resource "openstack_networking_port_v2" "k8s_worker_port" {
+  count               = var.worker_node_count * var.worker_nodes_per_pool
+  name                = "${var.k8s_cluster_name}-worker-port-${count.index + 1}"
+  network_id          = local.vpc_id
+  admin_state_up      = true
+  security_group_ids  = [openstack_networking_secgroup_v2.k8s_worker_security_group.id]
+
+  fixed_ip {
+    subnet_id  = local.master_subnet.id
+    ip_address = cidrhost(local.master_subnet.cidr, 20 + count.index)
+  }
+}
+
+# 8. Floating IP는 별도 association 리소스에서 포트에 연결됨
+
+# Floating IP 연결 상태 확인 제거 (로드밸런서를 통한 접속 사용)
+
+# 10. SSH 연결 대기 및 검증 (단순화)
+resource "null_resource" "wait_for_ssh" {
+  depends_on = [openstack_networking_floatingip_associate_v2.k8s_master_fip_association]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "SSH 연결 준비 중..."
+      
+      # SSH 키 권한 설정
+      chmod 0400 ${path.module}/keys/k8s-cluster-key
+      
+      FIP_ADDRESS="${openstack_networking_floatingip_v2.k8s_master_fip.address}"
+      echo "대상 서버: ubuntu@$FIP_ADDRESS"
+      
+      # 간단한 대기 (2분)
+      echo "SSH 서비스 준비를 위해 2분 대기..."
+      sleep 120
+      
+      # SSH 연결 테스트
+      echo "SSH 연결 테스트..."
+      ssh -i ${path.module}/keys/k8s-cluster-key \
+          -o StrictHostKeyChecking=no \
+          -o ConnectTimeout=30 \
+          -o BatchMode=yes \
+          -o UserKnownHostsFile=/dev/null \
+          ubuntu@$FIP_ADDRESS \
+          "echo 'SSH 연결 성공!'" || echo "SSH 연결 실패 - 수동으로 확인 필요"
+    EOT
+  }
+}
+
+# API 서버 가용성 대기 (단순화)
+resource "null_resource" "wait_for_k8s_api" {
+  depends_on = [null_resource.k8s_master_init]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "Kubernetes API 서비스 준비 대기 중..."
+      
+      # 간단한 대기 (2분)
+      echo "API 서버 준비를 위해 2분 대기..."
+      sleep 120
+      
+      # API 연결 테스트
+      echo "API 서버 연결 테스트..."
+      nc -zv ${openstack_networking_floatingip_v2.k8s_master_fip.address} 6443 || echo "API 연결 실패 - 수동으로 확인 필요"
+    EOT
+  }
+}
+
+# Helm 사전 정리(있다면 제거) - ingress-nginx
+resource "null_resource" "preclean_ingress" {
+  depends_on = [null_resource.copy_kubeconfig, null_resource.wait_for_k8s_api]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo "[preclean] ingress-nginx 기존 릴리즈 점검/정리"
+      if helm -n ingress-nginx status ingress-nginx >/dev/null 2>&1; then
+        echo "[preclean] 기존 ingress-nginx 발견 → 삭제"
+        helm -n ingress-nginx uninstall ingress-nginx || true
+      else
+        echo "[preclean] 기존 ingress-nginx 없음"
+      fi
+    EOT
+  }
+}
+
+# Helm 사전 정리(있다면 제거) - argocd
+resource "null_resource" "preclean_argocd" {
+  depends_on = [null_resource.copy_kubeconfig, null_resource.wait_for_k8s_api]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo "[preclean] argocd 기존 릴리즈 점검/정리"
+      if helm -n argocd status argocd >/dev/null 2>&1; then
+        echo "[preclean] 기존 argocd 발견 → 삭제"
+        helm -n argocd uninstall argocd || true
+      else
+        echo "[preclean] 기존 argocd 없음"
+      fi
+    EOT
+  }
+}
+
+# 10. Kubernetes 클러스터 초기화
+resource "null_resource" "k8s_master_init" {
+  depends_on = [null_resource.wait_for_ssh]
+
+  provisioner "remote-exec" {
+    connection {
+      host        = openstack_networking_floatingip_v2.k8s_master_fip.address
+      type        = "ssh"
+      user        = "ubuntu"
+      private_key = file(coalesce(var.ssh_private_key_path, "${path.module}/keys/k8s-cluster-key"))
+      timeout     = "10m"
+      agent       = false
+    }
+
+    script = "${path.module}/scripts/k8s-init.sh"
+  }
+}
+
+# 11. kubeconfig 파일을 로컬로 복사 (TLS 인증서 문제 해결)
+resource "null_resource" "copy_kubeconfig" {
+  depends_on = [null_resource.k8s_master_init, null_resource.ssh_connection_test]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      mkdir -p ~/.kube
+      
+      # SSH 호스트 키 정리 (IP 변경 시 발생하는 문제 해결)
+      ssh-keygen -R ${openstack_networking_floatingip_v2.k8s_master_fip.address} 2>/dev/null || true
+      
+      # 새로운 kubeconfig 복사
+      scp -i ${path.module}/keys/k8s-cluster-key \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          ubuntu@${openstack_networking_floatingip_v2.k8s_master_fip.address}:~/.kube/config \
+          ~/.kube/config
+      
+      # kubeconfig의 server를 퍼블릭 IP로 치환
+      KCFG=~/.kube/config
+      API_PUBLIC=https://${openstack_networking_floatingip_v2.k8s_master_fip.address}:6443
+      export API_PUBLIC
+      
+      echo "현재 kubeconfig server 주소 확인:"
+      grep -A 5 "server:" "$KCFG" || true
+      
+      # server 교체 (퍼블릭 IP) - 강제로 모든 server 주소 변경
+      sed -i '' "s#server: https://.*:6443#server: $${API_PUBLIC}#g" "$KCFG"
+      sed -i '' "s#server: https://10\..*:6443#server: $${API_PUBLIC}#g" "$KCFG"
+      
+      # TLS 인증서 검증 비활성화 (클러스터 섹션에만 적용)
+      sed -i '' '/^  cluster:/a\    insecure-skip-tls-verify: true' "$KCFG"
+      
+      echo "수정된 kubeconfig server 주소:"
+      grep -A 5 "server:" "$KCFG" || true
+      
+      echo "kubeconfig 업데이트 완료: $API_PUBLIC"
+    EOT
+  }
+}
+
+# kubeconfig 수동 재생성 (TLS 문제 해결용)
+resource "null_resource" "regenerate_kubeconfig" {
+  depends_on = [null_resource.copy_kubeconfig]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "=========================================="
+      echo "kubeconfig 수동 재생성"
+      echo "=========================================="
+      
+      # SSH 호스트 키 정리
+      ssh-keygen -R ${openstack_networking_floatingip_v2.k8s_master_fip.address} 2>/dev/null || true
+      
+      # SSH로 마스터 노드에 접속하여 kubeconfig 재생성
+      ssh -i ${path.module}/keys/k8s-cluster-key \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          ubuntu@${openstack_networking_floatingip_v2.k8s_master_fip.address} << 'EOF'
+        
+        # kubeconfig 재생성
+        sudo cp /etc/kubernetes/admin.conf ~/.kube/config
+        sudo chown ubuntu:ubuntu ~/.kube/config
+        
+        # 클러스터 정보 확인
+        kubectl cluster-info
+        kubectl get nodes
+        
+      EOF
+      
+      # 로컬로 kubeconfig 다시 복사
+      scp -i ${path.module}/keys/k8s-cluster-key \
+          -o StrictHostKeyChecking=no \
+          -o UserKnownHostsFile=/dev/null \
+          ubuntu@${openstack_networking_floatingip_v2.k8s_master_fip.address}:~/.kube/config \
+          ~/.kube/config
+      
+      # kubeconfig server 주소 수정
+      API_PUBLIC=https://${openstack_networking_floatingip_v2.k8s_master_fip.address}:6443
+      sed -i '' "s#server: https://.*:6443#server: $${API_PUBLIC}#g" ~/.kube/config
+      
+      # TLS 인증서 검증 비활성화 (클러스터 섹션에만 적용)
+      sed -i '' '/^  cluster:/a\    insecure-skip-tls-verify: true' ~/.kube/config
+      
+      echo "kubeconfig 재생성 완료: $API_PUBLIC"
+      echo "=========================================="
+    EOT
+  }
+}
+
+# kubeconfig 검증 및 kubectl 연결 테스트
+resource "null_resource" "kubeconfig_validation" {
+  depends_on = [null_resource.regenerate_kubeconfig]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "=========================================="
+      echo "kubeconfig 검증 및 연결 테스트"
+      echo "=========================================="
+      
+      # kubeconfig server 주소 확인
+      echo "현재 kubeconfig server 주소:"
+      kubectl config view --minify | grep server || true
+      
+      # TLS 설정 확인
+      echo "TLS 설정 확인:"
+      kubectl config view --minify | grep -A 5 "cluster:" || true
+      
+      # 클러스터 연결 테스트
+      echo "클러스터 연결 테스트:"
+      kubectl cluster-info || true
+      
+      # 노드 상태 확인
+      echo "노드 상태:"
+      kubectl get nodes || true
+      
+      echo "=========================================="
+    EOT
+  }
+}
+
+# SSH 연결 테스트 (단순화)
+resource "null_resource" "ssh_connection_test" {
+  depends_on = [null_resource.wait_for_ssh]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "SSH 연결 최종 테스트..."
+      
+      FIP_ADDRESS="${openstack_networking_floatingip_v2.k8s_master_fip.address}"
+      echo "Floating IP: $FIP_ADDRESS"
+      
+      # 간단한 연결 테스트
+      ping -c 1 $FIP_ADDRESS && echo "✅ Ping 성공" || echo "❌ Ping 실패"
+      nc -z -w3 $FIP_ADDRESS 22 && echo "✅ SSH 포트 열림" || echo "❌ SSH 포트 닫힘"
+    EOT
+  }
+}
+
+ 
+# Secret 파일들을 Kubernetes에 적용
+resource "null_resource" "apply_secrets" {
+  depends_on = [
+    null_resource.kubeconfig_validation,
+    null_resource.wait_for_k8s_api
+  ]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo "[secrets] Creating namespaces and applying Secret files..."
+      
+      # 필요한 네임스페이스들 생성
+      kubectl create namespace auth-service --dry-run=client -o yaml | kubectl apply -f -
+      kubectl create namespace mysql --dry-run=client -o yaml | kubectl apply -f -
+      kubectl create namespace redis --dry-run=client -o yaml | kubectl apply -f -
+      
+    EOT
+  }
+}
+
+# ArgoCD Application 매니페스트들을 자동으로 등록
+# 이제 ArgoCD가 GitOps 방식으로 애플리케이션들을 관리합니다
+resource "null_resource" "register_argocd_applications" {
+  depends_on = [
+    helm_release.argocd,
+    null_resource.apply_secrets,
+    null_resource.kubeconfig_validation,
+    null_resource.wait_for_k8s_api
+  ]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      set -e
+      echo "[argocd-apps] Registering ArgoCD Applications..."
+      
+      # ArgoCD가 준비될 때까지 대기
+      echo "Waiting for ArgoCD to be ready..."
+      kubectl wait --for=condition=available deployment/argocd-server -n argocd --timeout=300s
+      
+      # 기존 secrets Application이 있다면 삭제
+      kubectl delete application secrets -n argocd --ignore-not-found=true || true
+      
+      # Application 매니페스트들 적용
+      kubectl apply -f ${path.module}/applications/ || true
+      
+      # Secret 파일들 적용 (네임스페이스 생성 후)
+      echo "Applying secrets..."
+      kubectl apply -f ${path.module}/secret/ || true
+      
+      echo "[argocd-apps] ArgoCD Applications registered successfully"
+      
+      # auth-service Application 강제 동기화 (TLS 설정 반영)
+      echo "Syncing auth-service application..."
+      kubectl patch application auth-service -n argocd --type merge -p '{"operation":{"sync":{"syncOptions":["CreateNamespace=true"]}}}' || true
+    EOT
+  }
+}
+
+# 로컬 변수들
+locals {
+  vpc_id       = data.openstack_networking_network_v2.existing_vpc[0].id
+  master_subnet = data.openstack_networking_subnet_v2.existing_subnets[0]
+
+  # MySQL 엔드포인트 설정 (Kubernetes 내부 MySQL 사용)
+  mysql_endpoint_effective = "mysql.mysql.svc.cluster.local:3306"
+}
+
+# cert-manager 및 Let's Encrypt 제거 (Cloudflare 인증서 사용)
+
+############################################
+# LoadBalancer Floating IP 연결
+############################################
+
+# 마스터 노드용 Floating IP 생성 (SSH, K8s API 접속용)
+resource "openstack_networking_floatingip_v2" "k8s_master_fip" {
+  pool = var.floating_ip_pool
+}
+
+# 마스터 노드 Floating IP 연결
+resource "openstack_networking_floatingip_associate_v2" "k8s_master_fip_association" {
+  floating_ip = openstack_networking_floatingip_v2.k8s_master_fip.address
+  port_id     = openstack_networking_port_v2.k8s_master_port.id
+}
+
+# 로드밸런서용 Floating IP 생성 (HTTP/HTTPS용)
+resource "openstack_networking_floatingip_v2" "lb_fip" {
+  pool = var.floating_ip_pool
+  
+  # 고정 FIP 주소가 제공되면 해당 FIP를 재사용
+  address = length(var.lb_floating_ip_address) > 0 ? var.lb_floating_ip_address : null
+
+  lifecycle {
+    ignore_changes = [address]
+  }
+}
+
+# 로드밸런서에 Floating IP 자동 연결
+# 주의: 로드밸런서가 이미 생성되어 있어야 함
+resource "null_resource" "connect_lb_fip" {
+  depends_on = [openstack_networking_floatingip_v2.lb_fip]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "로드밸런서에 Floating IP 연결 중..."
+      echo "Floating IP: ${openstack_networking_floatingip_v2.lb_fip.address}"
+      
+      # OpenStack CLI를 사용하여 로드밸런서에 Floating IP 연결
+      # 로드밸런서 ID를 찾아서 Floating IP 연결
+      LB_ID=$(openstack loadbalancer list --name KEA-LB -f value -c id 2>/dev/null || echo "")
+      
+      if [ -n "$LB_ID" ]; then
+        echo "로드밸런서 ID: $LB_ID"
+        echo "Floating IP 연결 시도..."
+        
+        # 로드밸런서에 Floating IP 연결 (VIP에 연결)
+        openstack floating ip set --port $LB_ID ${openstack_networking_floatingip_v2.lb_fip.address} 2>/dev/null || {
+          echo "⚠️ 자동 연결 실패 - 수동으로 연결하세요"
+          echo "카카오클라우드 콘솔에서 로드밸런서에 Floating IP를 연결하세요"
+        }
+      else
+        echo "⚠️ 로드밸런서를 찾을 수 없습니다 - 수동으로 연결하세요"
+        echo "로드밸런서 이름: KEA-LB"
+        echo "Floating IP: ${openstack_networking_floatingip_v2.lb_fip.address}"
+      fi
+    EOT
+  }
+}
+
+# 로드밸런서 생성 (카카오클라우드 콘솔에서 수동 생성 필요)
+# 이 리소스는 실제로는 생성되지 않고, 수동으로 생성한 로드밸런서 정보만 참조
+resource "null_resource" "create_loadbalancer" {
+  depends_on = [openstack_networking_floatingip_v2.lb_fip]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "=========================================="
+      echo "로드밸런서 수동 생성 안내"
+      echo "=========================================="
+      echo "1. 카카오클라우드 콘솔에서 로드밸런서 생성:"
+      echo "   - 이름: KEA-LB"
+      echo "   - VPC: test"
+      echo "   - 서브넷: main"
+      echo ""
+      echo "2. 백엔드 서버 추가:"
+      echo "   - 서버 IP: ${openstack_compute_instance_v2.k8s_master[0].access_ip_v4}"
+      echo "   - 포트: 22, 80, 443, 6443"
+      echo ""
+      echo "3. Floating IP 연결:"
+      echo "   - Floating IP: ${openstack_networking_floatingip_v2.lb_fip.address}"
+      echo "   - 로드밸런서에 연결"
+      echo ""
+      echo "4. 로드밸런서 생성 완료 후 다음 명령 실행:"
+      echo "   terraform apply -target=null_resource.wait_for_lb_ready"
+      echo "=========================================="
+    EOT
+  }
+}
+
+# 로드밸런서 준비 대기
+resource "null_resource" "wait_for_lb_ready" {
+  depends_on = [null_resource.create_loadbalancer]
+
+  provisioner "local-exec" {
+    command = <<-EOT
+      echo "로드밸런서 준비 상태 확인 중..."
+      echo "Floating IP: ${openstack_networking_floatingip_v2.lb_fip.address}"
+      
+      # 로드밸런서 HTTP/HTTPS 포트 연결 테스트
+      for i in {1..30}; do
+        if nc -zv ${openstack_networking_floatingip_v2.lb_fip.address} 80 2>/dev/null; then
+          echo "✅ 로드밸런서 HTTP 포트 연결 성공"
+          break
+        fi
+        echo "⏳ 로드밸런서 연결 대기... (attempt $i/30)"
+        sleep 10
+      done
+      
+      if ! nc -zv ${openstack_networking_floatingip_v2.lb_fip.address} 80 2>/dev/null; then
+        echo "❌ 로드밸런서 연결 실패 - 수동으로 확인 필요"
+        exit 1
+      fi
+    EOT
+  }
+}
+
+# Fallback externalIPs 설정 제거 (카카오클라우드 콘솔에서 로드밸런서 사용)
+
+# OpenStack CCM 제거 (카카오클라우드 콘솔에서 로드밸런서 사용)
+

--- a/terraform/test/outputs.tf
+++ b/terraform/test/outputs.tf
@@ -1,0 +1,148 @@
+# 관리형 Kubernetes Engine 출력값들
+
+# Kubernetes Engine 정보
+output "k8s_engine_info" {
+  description = "Kubernetes Engine 클러스터 정보"
+  value = {
+    cluster_name = var.k8s_cluster_name
+    version      = var.k8s_version
+    worker_count = var.worker_node_count
+    status       = "생성됨"
+    console_url  = "https://console.kakaocloud.com/kubernetes"
+  }
+}
+
+# 네트워크 정보
+output "network_info" {
+  description = "네트워크 정보"
+  value = {
+    vpc_id    = var.existing_vpc_id
+    subnet_ids = var.existing_subnet_ids
+    security_group_id = openstack_networking_secgroup_v2.k8s_worker_security_group.id
+  }
+}
+
+# Kubernetes 클러스터 정보
+output "k8s_cluster_info" {
+  description = "Kubernetes 클러스터 정보"
+  value = {
+    cluster_name = var.k8s_cluster_name
+    version      = var.k8s_version
+    master_count = var.master_node_count
+    worker_count = var.worker_node_count
+    status       = "자체 구축 완료"
+  }
+}
+
+# 마스터 노드 정보
+output "master_node_info" {
+  description = "마스터 노드 정보"
+  value = {
+    public_ip  = openstack_networking_floatingip_v2.k8s_master_fip.address
+    private_ip = openstack_compute_instance_v2.k8s_master[0].access_ip_v4
+    name       = openstack_compute_instance_v2.k8s_master[0].name
+  }
+}
+
+# 로드밸런서 정보
+output "loadbalancer_info" {
+  description = "로드밸런서 정보"
+  value = {
+    floating_ip = openstack_networking_floatingip_v2.lb_fip.address
+    note        = "카카오클라우드 콘솔에서 로드밸런서 생성 후 이 Floating IP를 연결하세요"
+  }
+}
+
+# 워커 노드 정보
+output "worker_nodes_info" {
+  description = "워커 노드 정보"
+  value = {
+    count = var.worker_node_count
+    nodes = [for i in range(var.worker_node_count) : {
+      name       = openstack_compute_instance_v2.k8s_worker[i].name
+      private_ip = openstack_compute_instance_v2.k8s_worker[i].access_ip_v4
+    }]
+  }
+}
+
+# 데이터베이스 정보
+output "database_info" {
+  description = "데이터베이스 정보"
+  value = {
+    mysql_type = "Kubernetes 내부 MySQL (Helm)"
+    mysql_endpoint = local.mysql_endpoint_effective
+    redis_service = "redis-service.default.svc.cluster.local:6379"
+  }
+}
+
+# 클러스터 접속 정보
+output "cluster_access_info" {
+  description = "클러스터 접속 정보"
+  value = {
+    cluster_name = var.k8s_cluster_name
+    ssh_key_name = var.ssh_key_name
+    note = "카카오클라우드 CLI를 사용하여 클러스터에 접속하세요"
+    commands = [
+      "kc kubernetes cluster list",
+      "kc kubernetes cluster get-credentials ${var.k8s_cluster_name}",
+      "kubectl get nodes"
+    ]
+  }
+}
+
+# 서비스 연결 정보
+output "service_connection_info" {
+  description = "서비스 연결 정보"
+  value = {
+    mysql_service = local.mysql_endpoint_effective
+    note = "MySQL은 카카오클라우드 관리형 RDS, 나머지는 Helm으로 설치"
+  }
+}
+
+# Ingress Controller 정보
+output "ingress_controller_info" {
+  description = "Ingress Controller 정보"
+  value = {
+    name      = helm_release.nginx_ingress.name
+    namespace = helm_release.nginx_ingress.namespace
+    status    = helm_release.nginx_ingress.status
+    version   = helm_release.nginx_ingress.version
+  }
+}
+
+
+# ArgoCD 및 Ingress 테스트 방법 안내
+output "argocd_test_instructions" {
+  description = "ArgoCD 및 Ingress Controller 테스트 방법"
+  value = <<-EOT
+    OpenStack Kubernetes 클러스터에 ArgoCD와 Ingress Controller가 설치되었습니다!
+    
+           테스트 방법:
+           1. 클러스터에 연결:
+               ssh -i keys/k8s-cluster-key ubuntu@${openstack_networking_floatingip_v2.k8s_master_fip.address}
+       sudo cp /etc/kubernetes/admin.conf ~/.kube/config
+       sudo chown ubuntu:ubuntu ~/.kube/config
+    
+    2. ArgoCD 상태 확인:
+       kubectl get pods -n argocd
+       kubectl get svc -n argocd
+    
+    3. Ingress Controller 상태 확인:
+       kubectl get pods -n ingress-nginx
+       kubectl get svc -n ingress-nginx
+    
+    4. ArgoCD UI 접속:
+       kubectl port-forward -n argocd svc/argocd-server 8080:80
+       # 브라우저에서 http://localhost:8080 접속
+    
+    5. auth-service 애플리케이션 확인 (ArgoCD가 자동 배포):
+       kubectl get applications -n argocd
+       kubectl get pods -n auth-service
+       kubectl get svc -n auth-service
+       kubectl get ingress -n auth-service
+    
+    6. LoadBalancer IP 확인 및 테스트:
+       kubectl get svc -n ingress-nginx ingress-nginx-controller
+       # auth-service 엔드포인트로 테스트
+  EOT
+}

--- a/terraform/test/providers.tf
+++ b/terraform/test/providers.tf
@@ -1,0 +1,52 @@
+# Terraform 설정
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    openstack = {
+      source  = "terraform-provider-openstack/openstack"
+      version = ">= 1.40.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.1.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.7.0"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.13.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23.0"
+    }
+  }
+}
+
+# OpenStack Provider 설정 (카카오클라우드용)
+provider "openstack" {
+  auth_url                      = var.kc_auth_url
+  application_credential_id     = var.kc_application_credential_id
+  application_credential_secret = var.kc_application_credential_secret
+  region                        = var.kc_region
+}
+
+
+provider "helm" {
+  kubernetes = {
+    config_path = "/Users/parkyoungdu/.kube/config"
+  }
+}
+
+provider "kubernetes" {
+  config_path = "/Users/parkyoungdu/.kube/config"
+}
+
+# OpenStack Kubernetes 클러스터용 kubectl provider 설정
+provider "kubectl" {
+  config_path = "/Users/parkyoungdu/.kube/config"
+  insecure    = true  # TLS 인증서 검증 비활성화
+}

--- a/terraform/test/scripts/create-mysql-user.sh
+++ b/terraform/test/scripts/create-mysql-user.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+NAMESPACE=${NAMESPACE:-mysql}
+MYSQL_SECRET_NAME=${MYSQL_SECRET_NAME:-mysql-secrets}
+
+# MySQL 서비스 이름 자동 탐지 (환경변수 SERVICE_NAME가 없을 때)
+# Bitnami MySQL 차트는 일반적으로 Service 이름이 "mysql" 이지만, 환경마다 다를 수 있으므로 탐지합니다.
+SERVICE_NAME=${SERVICE_NAME:-$(kubectl get svc -n "$NAMESPACE" -l app.kubernetes.io/instance=mysql -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo mysql)}
+
+# MySQL 호스트 도메인 조립
+MYSQL_HOST="${SERVICE_NAME}.${NAMESPACE}.svc.cluster.local"
+
+# Secret에서 값 자동 로드 (환경변수 미설정 시)
+if [[ -z "${DB_USER:-}" || -z "${DB_PASS:-}" || -z "${DB_NAME:-}" ]]; then
+  echo "[mysql] Loading credentials from Secret '$MYSQL_SECRET_NAME' in namespace '$NAMESPACE'..."
+  # 존재 확인
+  if ! kubectl get secret "$MYSQL_SECRET_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
+    echo "[mysql] Secret '$MYSQL_SECRET_NAME' not found in namespace '$NAMESPACE'" >&2
+    echo "[mysql] Set DB_USER/DB_PASS/DB_NAME envs or create the Secret first." >&2
+    exit 1
+  fi
+  DB_USER=${DB_USER:-$(kubectl get secret "$MYSQL_SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.mysql-username}' | base64 -d)}
+  DB_PASS=${DB_PASS:-$(kubectl get secret "$MYSQL_SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.mysql-password}' | base64 -d)}
+  DB_NAME=${DB_NAME:-$(kubectl get secret "$MYSQL_SECRET_NAME" -n "$NAMESPACE" -o jsonpath='{.data.mysql-database}' | base64 -d 2>/dev/null || echo auth)}
+fi
+
+
+# MySQL 서비스 준비 대기
+echo "[mysql] Waiting for Service '$SERVICE_NAME' and endpoints in namespace '$NAMESPACE'..."
+# Service 존재 대기 (최대 300초)
+for i in $(seq 1 60); do
+  if kubectl get svc "$SERVICE_NAME" -n "$NAMESPACE" >/dev/null 2>&1; then
+    break
+  fi
+  sleep 5
+done
+
+# Endpoints 준비 대기 (최대 600초)
+for i in $(seq 1 120); do
+  if kubectl get endpoints "$SERVICE_NAME" -n "$NAMESPACE" -o jsonpath='{.subsets[0].addresses[0].ip}' 2>/dev/null | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' >/dev/null; then
+    break
+  fi
+  sleep 5
+done
+
+# 파드 Ready 대기 (라벨 기반)
+kubectl wait --for=condition=Ready pod -l app.kubernetes.io/instance=mysql -n "$NAMESPACE" --timeout=600s || true
+
+
+echo "[mysql] Creating user '$DB_USER' on database '$DB_NAME'..."
+kubectl run mysql-client --rm -it --restart='Never' \
+  --image docker.io/bitnami/mysql:9.4.0-debian-12-r1 \
+  --namespace "$NAMESPACE" \
+  --env MYSQL_ROOT_PASSWORD="$DB_PASS" \
+  --command -- mysql -h "$MYSQL_HOST" -uroot -p"$DB_PASS" -e "
+    CREATE DATABASE IF NOT EXISTS \`$DB_NAME\`;
+    CREATE USER IF NOT EXISTS '$DB_USER'@'%' IDENTIFIED BY '$DB_PASS';
+    GRANT ALL PRIVILEGES ON \`$DB_NAME\`.* TO '$DB_USER'@'%';
+    FLUSH PRIVILEGES;
+    SHOW DATABASES;
+  "
+
+echo "[mysql] Done."
+

--- a/terraform/test/scripts/k8s-init.sh
+++ b/terraform/test/scripts/k8s-init.sh
@@ -1,0 +1,170 @@
+#!/bin/bash
+
+# Kubernetes 마스터 노드 초기화 스크립트
+
+set -e
+
+echo "🚀 Kubernetes 마스터 노드 초기화 시작..."
+
+# 0. 이미 초기화되어 있으면 init 스킵(토큰/HTTP 서빙만 보장)
+if [ -f /etc/kubernetes/admin.conf ]; then
+  echo "ℹ️  이미 kubeadm init 완료 상태. 토큰/HTTP 서빙만 보장합니다."
+  JOIN_COMMAND=$(kubeadm token create --print-join-command)
+  echo "$JOIN_COMMAND" | sudo tee /home/ubuntu/join-command.sh >/dev/null
+  sudo chmod +x /home/ubuntu/join-command.sh
+
+  # join-command 8080 서빙 보장
+  sudo bash -c 'cat >/etc/systemd/system/join-http.service <<UNIT
+[Unit]
+Description=Serve join-command over HTTP (port 8080)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ubuntu
+ExecStart=/usr/bin/python3 -m http.server 8080
+Restart=always
+RestartSec=5s
+User=ubuntu
+Group=ubuntu
+
+[Install]
+WantedBy=multi-user.target
+UNIT'
+  sudo systemctl daemon-reload
+  sudo systemctl enable --now join-http.service || true
+
+  echo "✅ 준비 완료 (init 스킵)."
+  echo "📝 조인 토큰: $JOIN_COMMAND"
+  exit 0
+fi
+
+# 1. 시스템 업데이트 (최적화)
+sudo rm -rf /var/lib/apt/lists/* || true
+sudo apt-get clean || true
+sudo sed -i 's|http://archive.ubuntu.com/ubuntu|https://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
+sudo sed -i 's|http://security.ubuntu.com/ubuntu|https://security.ubuntu.com/ubuntu|g' /etc/apt/sources.list || true
+
+# 필요한 패키지만 설치 (apt-transport-https는 이미 설치되어 있을 가능성 높음)
+sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30
+sudo apt-get install -y ca-certificates curl gnupg lsb-release
+
+# 2. Docker 설치 (최적화)
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# 3. Kubernetes 설치 (Ubuntu 20.04용)
+sudo mkdir -p /etc/apt/keyrings
+curl -fsSL https://pkgs.k8s.io/core:/stable:/v1.28/deb/Release.key | sudo gpg --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+echo 'deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/v1.28/deb/ /' | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt-get update -o Acquire::Retries=3 -o Acquire::http::Timeout=30
+sudo apt-get install -y kubelet kubeadm kubectl
+
+# 4. kubelet 버전 고정 및 containerd 설정
+sudo apt-mark hold kubelet kubeadm kubectl
+
+# 5. 프리리퀴짓: swap/커널 설정
+sudo swapoff -a || true
+sudo sed -i.bak '/\sswap\s/s/^/#/' /etc/fstab || true
+sudo modprobe br_netfilter || true
+echo 1 | sudo tee /proc/sys/net/bridge/bridge-nf-call-iptables >/dev/null || true
+echo 1 | sudo tee /proc/sys/net/ipv4/ip_forward >/dev/null || true
+cat <<EOF | sudo tee /etc/sysctl.d/k8s.conf >/dev/null
+net.bridge.bridge-nf-call-iptables = 1
+net.ipv4.ip_forward = 1
+EOF
+sudo sysctl --system >/dev/null
+
+# 6. containerd 설정 (가능한 경우에만 기본 설정 생성 후 SystemdCgroup 적용)
+sudo mkdir -p /etc/containerd
+if command -v containerd >/dev/null 2>&1; then
+  if containerd config default >/dev/null 2>&1; then
+    containerd config default | sudo tee /etc/containerd/config.toml >/dev/null
+  fi
+  # SystemdCgroup=true 적용
+  if [ -f /etc/containerd/config.toml ]; then
+    sudo sed -i 's/^\(\s*SystemdCgroup\s*=\s*\)false/\1true/' /etc/containerd/config.toml || true
+  fi
+fi
+# crictl 엔드포인트 설정
+cat <<EOF | sudo tee /etc/crictl.yaml >/dev/null
+runtime-endpoint: unix:///run/containerd/containerd.sock
+image-endpoint: unix:///run/containerd/containerd.sock
+EOF
+sudo systemctl restart containerd || true
+sudo systemctl enable containerd || true
+
+# 7. Docker 서비스 시작 (필요 시)
+sudo systemctl enable docker || true
+sudo systemctl start docker || true
+
+# 8. Kubernetes 초기화 (퍼블릭 IP SAN 포함)
+MASTER_INTERNAL_IP=$(hostname -I | awk '{print $1}')
+MASTER_PUBLIC_IP=$(curl -s http://ifconfig.me || true)
+if [ -n "$MASTER_PUBLIC_IP" ]; then
+  sudo kubeadm init \
+    --pod-network-cidr=10.244.0.0/16 \
+    --apiserver-advertise-address=$MASTER_INTERNAL_IP \
+    --apiserver-cert-extra-sans=$MASTER_INTERNAL_IP,$MASTER_PUBLIC_IP
+else
+  sudo kubeadm init \
+    --pod-network-cidr=10.244.0.0/16 \
+    --apiserver-advertise-address=$MASTER_INTERNAL_IP
+fi
+
+# 9. kubectl 설정
+mkdir -p $HOME/.kube
+sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
+sudo chown $(id -u):$(id -g) $HOME/.kube/config
+
+# 10. Flannel 네트워크 플러그인 설치
+kubectl apply -f https://raw.githubusercontent.com/coreos/flannel/master/Documentation/kube-flannel.yml
+
+# 11. 마스터 노드에서도 Pod 스케줄링 허용
+kubectl taint nodes --all node-role.kubernetes.io/control-plane-
+
+# 12. 조인 토큰 생성 및 저장
+JOIN_COMMAND=$(kubeadm token create --print-join-command)
+echo "$JOIN_COMMAND" | sudo tee /home/ubuntu/join-command.sh >/dev/null
+sudo chmod +x /home/ubuntu/join-command.sh
+
+# 13. join-command를 8080으로 지속 서빙(systemd)
+sudo bash -c 'cat >/etc/systemd/system/join-http.service <<UNIT
+[Unit]
+Description=Serve join-command over HTTP (port 8080)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory=/home/ubuntu
+ExecStart=/usr/bin/python3 -m http.server 8080
+Restart=always
+RestartSec=5s
+User=ubuntu
+Group=ubuntu
+
+[Install]
+WantedBy=multi-user.target
+UNIT'
+sudo systemctl daemon-reload
+sudo systemctl enable --now join-http.service || true
+
+# 14. 마스터 퍼블릭 IP 파일로 저장(워커에서 참조 가능)
+MASTER_PUBLIC_IP="$(curl -s http://ifconfig.me || true)"
+if [ -n "$MASTER_PUBLIC_IP" ]; then
+  echo "$MASTER_PUBLIC_IP" | sudo tee /home/ubuntu/master-public-ip.txt >/dev/null
+fi
+
+echo "✅ Kubernetes 마스터 노드 초기화 완료!"
+echo "📝 조인 토큰이 /home/ubuntu/join-command.sh에 저장되었습니다:"
+echo "$JOIN_COMMAND"
+
+# 15. 동적 스토리지 프로비저너(local-path) 설치 및 기본 StorageClass 지정
+echo "📦 Installing local-path-provisioner and setting as default StorageClass..."
+kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/v0.0.26/deploy/local-path-storage.yaml
+kubectl annotate storageclass local-path storageclass.kubernetes.io/is-default-class=true --overwrite || true
+kubectl get sc

--- a/terraform/test/scripts/k8s-worker-join.sh
+++ b/terraform/test/scripts/k8s-worker-join.sh
@@ -1,0 +1,58 @@
+#!/bin/bash
+
+# Kubernetes 워커 노드 조인 스크립트
+
+set -e
+
+echo "🚀 Kubernetes 워커 노드 조인 시작..."
+
+# 1. 시스템 업데이트
+sudo apt-get update
+sudo apt-get install -y apt-transport-https ca-certificates curl
+
+# 2. Docker 설치
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
+echo "deb [arch=amd64 signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+sudo apt-get update
+sudo apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# 3. Kubernetes 설치
+curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | sudo apt-key add -
+echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+sudo apt-get update
+sudo apt-get install -y kubelet kubeadm kubectl
+
+# 4. Docker 서비스 시작
+sudo systemctl enable docker
+sudo systemctl start docker
+
+# 5. 마스터 IP 결정 우선순위: 인자 > 환경변수 > 파일 > 기본 사설 IP
+MASTER_IP_ARG="$1"
+MASTER_IP_ENV="${MASTER_IP:-}"
+MASTER_IP_FILE="/home/ubuntu/master-public-ip.txt"
+DEFAULT_MASTER_IP="10.0.0.10"
+
+if [ -n "$MASTER_IP_ARG" ]; then
+  MASTER_IP="$MASTER_IP_ARG"
+elif [ -n "$MASTER_IP_ENV" ]; then
+  MASTER_IP="$MASTER_IP_ENV"
+elif [ -f "$MASTER_IP_FILE" ]; then
+  MASTER_IP="$(cat "$MASTER_IP_FILE" | tr -d '\n' | xargs)"
+else
+  MASTER_IP="$DEFAULT_MASTER_IP"
+fi
+
+echo "🛰️  사용 마스터 IP: $MASTER_IP"
+
+# 6. 마스터 노드에서 조인 토큰 가져오기
+JOIN_COMMAND=$(ssh -o StrictHostKeyChecking=no ubuntu@$MASTER_IP "cat /home/ubuntu/join-command.sh" || true)
+
+if [ -z "$JOIN_COMMAND" ]; then
+  echo "❌ 마스터에서 조인 명령을 가져오지 못했습니다. 마스터 초기화가 완료되었는지 확인하세요."
+  exit 1
+fi
+
+# 7. 클러스터에 조인
+sudo $JOIN_COMMAND
+
+echo "✅ Kubernetes 워커 노드 조인 완료!"

--- a/terraform/test/variables.tf
+++ b/terraform/test/variables.tf
@@ -1,0 +1,197 @@
+# OpenStack CCM 관련 변수들 제거 (카카오클라우드 콘솔에서 로드밸런서 사용)
+
+# 로드밸런서 Floating IP 주소 (선택사항)
+variable "lb_floating_ip_address" {
+  description = "로드밸런서용 Floating IP 주소 (선택사항)"
+  type        = string
+  default     = ""
+}
+
+# letsencrypt_email 변수 제거 (Cloudflare 인증서 사용)
+# 카카오클라우드 인증 정보
+variable "kc_auth_url" {
+  description = "카카오클라우드 인증 URL"
+  type        = string
+  default     = "https://iam.kakaocloud.com/identity/v3"
+}
+
+variable "kc_application_credential_id" {
+  description = "카카오클라우드 Application Credential ID"
+  type        = string
+  sensitive   = true
+}
+
+variable "kc_application_credential_secret" {
+  description = "카카오클라우드 Application Credential Secret"
+  type        = string
+  sensitive   = true
+}
+
+variable "kc_region" {
+  description = "카카오클라우드 리전"
+  type        = string
+  default     = "kr-central-2"
+}
+
+# Trove(Database) 엔드포인트 수동 지정(서비스 카탈로그에 없을 때 필요)
+variable "kc_trove_endpoint" {
+  description = "Optional. Trove(Database) 엔드포인트 URL (예: https://database.kr-central-2.kakaocloud.com/v1.0)"
+  type        = string
+  default     = ""
+}
+
+# 자체 구축 Kubernetes 클러스터용 변수들
+
+# Kubernetes 클러스터 설정
+variable "k8s_cluster_name" {
+  description = "Kubernetes 클러스터 이름"
+  type        = string
+  default     = "k8s-cluster"
+}
+
+variable "k8s_version" {
+  description = "Kubernetes 버전"
+  type        = string
+  default     = "1.28"
+}
+
+variable "master_node_count" {
+  description = "마스터 노드 수"
+  type        = number
+  default     = 1
+}
+
+variable "worker_node_count" {
+  description = "워커 노드 수"
+  type        = number
+  default     = 3
+}
+
+variable "worker_nodes_per_pool" {
+  description = "워커 노드 풀당 노드 수"
+  type        = number
+  default     = 1
+}
+
+variable "master_flavor_id" {
+  description = "마스터 노드 Flavor ID"
+  type        = string
+  default     = "ff64c2aa-2e80-4cfd-a646-2b475270d31e" # m2a.large
+}
+
+variable "master_flavor_name" {
+  description = "마스터 노드 Flavor 이름(예: m2a.xlarge - 4vCPU/8GiB). 지정 시 ID보다 우선"
+  type        = string
+  default     = "m2a.xlarge"
+}
+
+variable "worker_flavor_id" {
+  description = "워커 노드 Flavor ID"
+  type        = string
+  default     = "ff64c2aa-2e80-4cfd-a646-2b475270d31e" # m2a.large
+}
+
+variable "master_image_id" {
+  description = "마스터 노드 이미지 ID"
+  type        = string
+  default     = "044eae16-ecc2-4f74-9345-5a9fe90d80a9" # Ubuntu 20.04 LTS
+}
+
+variable "worker_image_id" {
+  description = "워커 노드 이미지 ID"
+  type        = string
+  default     = "044eae16-ecc2-4f74-9345-5a9fe90d80a9" # Ubuntu 20.04 LTS
+}
+
+variable "master_volume_size" {
+  description = "마스터 노드 볼륨 크기 (GB)"
+  type        = number
+  default     = 30
+}
+
+variable "worker_volume_size" {
+  description = "워커 노드 볼륨 크기 (GB)"
+  type        = number
+  default     = 30
+}
+
+# 네트워크 설정
+variable "existing_vpc_id" {
+  description = "기존 VPC ID"
+  type        = string
+  default     = "38717207-42ed-418c-8ed4-e8cc99c6d2b2"
+}
+
+variable "floating_ip_pool" {
+  description = "Floating IP 풀 이름"
+  type        = string
+  default     = "EXTERNAL"
+}
+
+# 마스터 노드 Floating IP (임시 접근용)
+variable "master_floating_ip_address" {
+  description = "Optional. 재사용할 마스터 Floating IP 주소"
+  type        = string
+  default     = ""
+}
+
+# API 서버 대기 타임아웃(초)
+variable "api_wait_timeout_seconds" {
+  description = "API 서버 가용성 대기 타임아웃(초)"
+  type        = number
+  default     = 300
+}
+
+variable "existing_subnet_ids" {
+  description = "기존 서브넷 ID 목록"
+  type        = list(string)
+  default     = [
+    "3ec3dfb1-1942-4884-871d-e379add7387a", # main 서브넷
+    "643cfe6d-391b-4725-9b5b-3b49bfc5d86e", # test_d354b_sn_1
+    "98f4bc8e-a08b-4d56-90a4-00253b553441", # test_d354b_sn_2
+    "8e5315c6-20b9-4f82-87aa-d4de575520d7"  # test_d354b_sn_3
+  ]
+}
+
+variable "ssh_private_key_path" {
+  description = "OpenStack 키페어와 매칭되는 로컬 프라이빗 키 경로"
+  type        = string
+  default     = ""
+}
+
+# SSH 키 설정
+variable "ssh_key_name" {
+  description = "SSH 키페어 이름"
+  type        = string
+  default     = "k8s-cluster-key"
+}
+
+# 프로젝트 설정
+variable "project_name" {
+  description = "프로젝트 이름"
+  type        = string
+  default     = "infra-project"
+}
+
+variable "environment" {
+  description = "환경"
+  type        = string
+  default     = "dev"
+}
+
+variable "tags" {
+  description = "리소스 태그"
+  type        = map(string)
+  default = {
+    Environment = "dev"
+    ManagedBy   = "Terraform"
+    Owner       = "DevOps Team"
+    Project     = "INFRA"
+  }
+}
+
+variable "enable_argocd" {
+  description = "ArgoCD 설치 여부 (2단계 적용)"
+  type        = bool
+  default     = false
+}


### PR DESCRIPTION
## 🚀 주요 변경사항

### 📋 인프라 구성
- **Kakao Cloud OpenStack** 기반 Kubernetes 클러스터 구축
- **마스터 노드 1개** (m2a.xlarge) + **워커 노드 3개** (m2a.large)
- **Ubuntu 20.04 LTS** 이미지 사용
- **Kubernetes 1.28** 버전

### 🔧 Kubernetes 구성요소
- **nginx-ingress**: LoadBalancer 타입, External IP 설정
- **ArgoCD**: GitOps 기반 애플리케이션 배포
- **Redis**: Helm 차트로 배포, NetworkPolicy 적용
- **auth-service**: Spring Boot 애플리케이션

### 🌐 네트워크 설정
- **VPC**: 기존 네트워크 활용 (4개 서브넷)
- **보안그룹**: 마스터/워커/LB별 세분화된 규칙
- **Floating IP**: 마스터(210.109.55.203), LB(210.109.55.201)

### 🔒 보안
- **SSH 키**: 새로운 키 생성 및 적용
- **민감한 정보**: Git 히스토리에서 완전 제거
- **NetworkPolicy**: Redis 접근 제어

### 📁 파일 구조
- k8s/: Kubernetes 매니페스트 파일들
- terraform/test/: Terraform 인프라 코드
- terraform/test/applications/: ArgoCD 애플리케이션 정의
- terraform/test/helm/: Helm 차트 설정

## ✅ 테스트 완료
- 클러스터 정상 구동 확인
- ArgoCD 애플리케이션 배포 확인
- nginx-ingress 외부 접근 확인
- auth-service Swagger UI 접근 확인

## 🔗 관련 이슈
- PRJ-79: Kakao Cloud 인프라 구축
- PRJ-76: Terraform Kakao 연결

---
**주의**: 민감한 정보(secrets, keys, tfvars)는 Git에 포함되지 않습니다.